### PR TITLE
CI to generate javadocs and upload it as an artifact

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,6 +52,9 @@ jobs:
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 
+    - name: Generate Javadoc
+      run: mvn javadoc:javadoc
+
     - name: Upload Javadocs as artifact
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Generates as an artifact in Github actions that can be downloaded:

![image](https://github.com/user-attachments/assets/6e32dde3-c45e-49c4-b760-db79cf95c411)
